### PR TITLE
Lesetilgang i syfo-sendt-sykmelding for min-side-arbeidsgiver-api

### DIFF
--- a/topics/sykmelding/syfo-sendt-sykmelding.yaml
+++ b/topics/sykmelding/syfo-sendt-sykmelding.yaml
@@ -45,3 +45,6 @@ spec:
     - team: flex
       application: sykepengesoknad-altinn
       access: read
+    - team: fager
+      application: min-side-arbeidsgiver-api
+      access: read


### PR DESCRIPTION
Innloggede nærmeste ledere så tidligere antall aktive sykmeldinger
på "min side arbeidsgiver". Dette ble hentet via et REST-api, men viste
seg å fungere dårlig, og ble derfor fjernet. Vi implementerer dette
på nytt ved å utlede det fra syfo-sendt-sykmelding. Løsningsforslag
er diskutert med Andreas Nilsen.

Se slack-tråder:
https://nav-it.slack.com/archives/CMA3XV997/p1634221208194000
https://nav-it.slack.com/archives/CMA3XV997/p1655281730369969