### PR TITLE
Gi sporhund tilgang til legeerklæringer-topicet

### DIFF
--- a/topics/legeerklaering/legeerklaering.yaml
+++ b/topics/legeerklaering/legeerklaering.yaml
@@ -33,3 +33,6 @@ spec:
     - team: teamsykefravr
       application: isbehandlerdialog
       access: read
+    - team: tbd
+      application: sporhund
+      access: read


### PR DESCRIPTION
På sykepenger skal vi støtte å sende og motta dialogmeldinger til/fra behandler, og har derfor behov for å kunne lese legeerklæringer også.