### PR TITLE
Sykepenger trenger ikke legeerklæringer

### DIFF
--- a/topics/legeerklaering/legeerklaering.yaml
+++ b/topics/legeerklaering/legeerklaering.yaml
@@ -33,6 +33,3 @@ spec:
     - team: teamsykefravr
       application: isbehandlerdialog
       access: read
-    - team: tbd
-      application: sporhund
-      access: read


### PR DESCRIPTION
I begynnelsen av utviklingen trodde vi at vi trengte tilgang til topicet for legeerklæringer. Etter vært så ser det ut som at vi kun skal bruke forespørsel og trenger ikke lengre tilgang